### PR TITLE
Adjust bowl_econ function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: howzatR
 Title: Useful Functions for Cricket Analysis
-Version: 1.0.0.9000
+Version: 1.0.0.9001
 Authors@R: 
     person("Luke", "Lockley", , "luke.lockley@btinternet.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7028-1499"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Update package `DESCRIPTION` with `URL` and `BugReports` entries
 * Add how to install stable version of howzatR in `README` 
+* Update `bowl_econ` function to include parameter `type` to allow to calculate Economy Rate per six ball overs, five ball sets or hundred balls bowled
+* Update `README` to include examples of the above
 
 # howzatR 1.0.0
 

--- a/R/bowling_basics.R
+++ b/R/bowling_basics.R
@@ -3,20 +3,26 @@
 
 #' Bowler Economy Rate
 #'
-#' Calculates bowlers' economy rate over six ball overs.
+#' Calculates bowlers' economy rate over six ball overs, five ball sets or per hundred balls.
 #'
-#' @param balls_bowled number of balls bowled. Data in terms of six ball overs.
+#' @param balls_bowled number of balls bowled. Data in terms of six ball overs,
 #'                     please convert to \code{\link{overs_to_balls}} to get it terms of `balls bowled`
-#' @param runs_conceded total runs conceded by bowler across the overs bowled.
-#'
-#' @return Economy rate across the number of overs bowled.
+#' @param runs_conceded total runs conceded by bowler across the overs, sets or per hundred balls bowled.
+#' @param type whether we are calculating economy over six ball overs, sets or per hundred balls bowled.
+#'             Options "overs", "sets", "per_100". Defaults to overs
+
+#' @return Economy rate across the number of overs, sets or per hundred balls bowled.
 #' @export
 #'
 #' @section Additional Information:
-#' Bowling economy rate is average number of runs scored per over bowled.
-#' A value of 9.5 indicates an average of 9.5 runs are scored per over bowled. The higher the number the more
-#' detrimental is for the bowler. Runs scored through byes & leg byes are \strong{excluded} from runs conceded by the bowler,
-#' however wides and no-balls are \strong{included} in the bowler's figures.
+#' Bowling economy rate is average number of runs scored per over or sets bowled.
+#'   * If using overs, a value of 9.5 indicates an average of 9.5 runs are scored per six ball over bowled.
+#'   * If using sets, a value of 9.5 indicates an average of 9.5 runs are scored per five ball set bowled.
+#'   * If using here, a value of 9.5 indicates an average of 9.5 runs are scored per hundred balls bowled.
+#' This the official statistic used by [The Hundred.](https://www.thehundred.com/stats?stat=econRatePerHundred&type=men&year=2022) \cr
+#'   \cr
+#' The higher the number the more detrimental is for the bowler. Runs scored through byes & leg byes are \strong{excluded} from runs conceded by the bowler,
+#' however wides and no-balls are \strong{included} in the bowler's figures. \cr
 #' More info [here.](https://en.wikipedia.org/wiki/Economy_rate)
 #'
 #'
@@ -25,10 +31,29 @@
 #' bowl_econ(balls_bowled = 60, runs_conceded = 45)
 #' bowl_econ(
 #'   balls_bowled = overs_to_balls(overs = 7.1),
-#'   runs_conceded = 26
+#'   runs_conceded = 26,
+#'   type = "overs"
 #' )
-bowl_econ <- function(balls_bowled, runs_conceded) {
-  6 * (runs_conceded / balls_bowled)
+#'
+#' bowl_econ(balls_bowled = 30, runs_conceded = 35, type = "sets")
+#'
+#' bowl_econ(balls_bowled = 22, runs_conceded = 19, type = "per_100")
+#'
+bowl_econ <- function(balls_bowled, runs_conceded, type = "overs") {
+
+  # Named List of Balls within type (overs contains 6 Balls, sets contains 5 Balls & per_100 contains 100)
+  type_list <- list(overs = 6, sets = 5, per_100 = 100)
+
+  # lowercase type
+  type <- tolower(type)
+
+  # If type not in list than needs to be re-supplied
+  if (!(type %in% names(type_list))) {
+    rlang::abort(message = "Type can either be overs or sets. Please Amend!")
+  }
+
+  # Calculate Economy Rate
+  type_list[[type]] * (runs_conceded / balls_bowled)
 }
 
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -75,14 +75,17 @@ bowl_raw_df
 ## Analysis
 bowl_df <- bowl_raw_df %>%
   mutate(
-    Economy = bowl_econ(balls_bowled = Balls_Bowled, runs_conceded = Runs_Conceded),
+    Economy_overs = bowl_econ(balls_bowled = Balls_Bowled, runs_conceded = Runs_Conceded, type = "overs"),
+    Economy_sets = bowl_econ(balls_bowled = Balls_Bowled, runs_conceded = Runs_Conceded, type = "sets"),
+    Economy_hundred = bowl_econ(balls_bowled = Balls_Bowled, runs_conceded = Runs_Conceded, type = "per_100"),
     Average = bowl_avg(runs_conceded = Runs_Conceded, wickets_taken = Wickets),
     Strike_Rate = bowl_sr(balls_bowled = Balls_Bowled, wickets_taken = Wickets),
     Overs = balls_to_overs(balls = Balls_Bowled)
   ) %>%
   select(
     Player, Balls_Bowled, Overs, Runs_Conceded,
-    Wickets, Economy, Average, Strike_Rate
+    Wickets, Economy_overs, Economy_sets, Economy_hundred,
+    Average, Strike_Rate
   )
 
 ## Results

--- a/README.md
+++ b/README.md
@@ -87,24 +87,27 @@ bowl_raw_df
 ## Analysis
 bowl_df <- bowl_raw_df %>%
   mutate(
-    Economy = bowl_econ(balls_bowled = Balls_Bowled, runs_conceded = Runs_Conceded),
+    Economy_overs = bowl_econ(balls_bowled = Balls_Bowled, runs_conceded = Runs_Conceded, type = "overs"),
+    Economy_sets = bowl_econ(balls_bowled = Balls_Bowled, runs_conceded = Runs_Conceded, type = "sets"),
+    Economy_hundred = bowl_econ(balls_bowled = Balls_Bowled, runs_conceded = Runs_Conceded, type = "per_100"),
     Average = bowl_avg(runs_conceded = Runs_Conceded, wickets_taken = Wickets),
     Strike_Rate = bowl_sr(balls_bowled = Balls_Bowled, wickets_taken = Wickets),
     Overs = balls_to_overs(balls = Balls_Bowled)
   ) %>%
   select(
     Player, Balls_Bowled, Overs, Runs_Conceded,
-    Wickets, Economy, Average, Strike_Rate
+    Wickets, Economy_overs, Economy_sets, Economy_hundred,
+    Average, Strike_Rate
   )
 
 ## Results
 bowl_df
-#>     Player Balls_Bowled Overs Runs_Conceded Wickets  Economy  Average
-#> 1 E. Apple          560  93.2           235      15 2.517857 15.66667
-#> 2  F. Pear          754 125.4           567      21 4.511936 27.00000
-#> 3 G. Grape          234  39.0           270       7 6.923077 38.57143
-#>   Strike_Rate
-#> 1    37.33333
-#> 2    35.90476
-#> 3    33.42857
+#>     Player Balls_Bowled Overs Runs_Conceded Wickets Economy_overs Economy_sets
+#> 1 E. Apple          560  93.2           235      15      2.517857     2.098214
+#> 2  F. Pear          754 125.4           567      21      4.511936     3.759947
+#> 3 G. Grape          234  39.0           270       7      6.923077     5.769231
+#>   Economy_hundred  Average Strike_Rate
+#> 1        41.96429 15.66667    37.33333
+#> 2        75.19894 27.00000    35.90476
+#> 3       115.38462 38.57143    33.42857
 ```

--- a/man/bowl_econ.Rd
+++ b/man/bowl_econ.Rd
@@ -4,33 +4,48 @@
 \alias{bowl_econ}
 \title{Bowler Economy Rate}
 \usage{
-bowl_econ(balls_bowled, runs_conceded)
+bowl_econ(balls_bowled, runs_conceded, type = "overs")
 }
 \arguments{
-\item{balls_bowled}{number of balls bowled. Data in terms of six ball overs.
+\item{balls_bowled}{number of balls bowled. Data in terms of six ball overs,
 please convert to \code{\link{overs_to_balls}} to get it terms of \verb{balls bowled}}
 
-\item{runs_conceded}{total runs conceded by bowler across the overs bowled.}
+\item{runs_conceded}{total runs conceded by bowler across the overs, sets or per hundred balls bowled.}
+
+\item{type}{whether we are calculating economy over six ball overs, sets or per hundred balls bowled.
+Options "overs", "sets", "per_100". Defaults to overs}
 }
 \value{
-Economy rate across the number of overs bowled.
+Economy rate across the number of overs, sets or per hundred balls bowled.
 }
 \description{
-Calculates bowlers' economy rate over six ball overs.
+Calculates bowlers' economy rate over six ball overs, five ball sets or per hundred balls.
 }
 \section{Additional Information}{
 
-Bowling economy rate is average number of runs scored per over bowled.
-A value of 9.5 indicates an average of 9.5 runs are scored per over bowled. The higher the number the more
-detrimental is for the bowler. Runs scored through byes & leg byes are \strong{excluded} from runs conceded by the bowler,
-however wides and no-balls are \strong{included} in the bowler's figures.
+Bowling economy rate is average number of runs scored per over or sets bowled.
+\itemize{
+\item If using overs, a value of 9.5 indicates an average of 9.5 runs are scored per six ball over bowled.
+\item If using sets, a value of 9.5 indicates an average of 9.5 runs are scored per five ball set bowled.
+\item If using here, a value of 9.5 indicates an average of 9.5 runs are scored per hundred balls bowled.
+This the official statistic used by \href{https://www.thehundred.com/stats?stat=econRatePerHundred&type=men&year=2022}{The Hundred.} \cr
+\cr
+The higher the number the more detrimental is for the bowler. Runs scored through byes & leg byes are \strong{excluded} from runs conceded by the bowler,
+however wides and no-balls are \strong{included} in the bowler's figures. \cr
 More info \href{https://en.wikipedia.org/wiki/Economy_rate}{here.}
+}
 }
 
 \examples{
 bowl_econ(balls_bowled = 60, runs_conceded = 45)
 bowl_econ(
   balls_bowled = overs_to_balls(overs = 7.1),
-  runs_conceded = 26
+  runs_conceded = 26,
+  type = "overs"
 )
+
+bowl_econ(balls_bowled = 30, runs_conceded = 35, type = "sets")
+
+bowl_econ(balls_bowled = 22, runs_conceded = 19, type = "per_100")
+
 }

--- a/man/howzatR-package.Rd
+++ b/man/howzatR-package.Rd
@@ -8,6 +8,14 @@
 \description{
 Helping to calculate cricket specific problems in a tidy & simple manner.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/lukelockley/howzatR}
+  \item Report bugs at \url{https://github.com/lukelockley/howzatR/issues}
+}
+
+}
 \author{
 \strong{Maintainer}: Luke Lockley \email{luke.lockley@btinternet.com} (\href{https://orcid.org/0000-0002-7028-1499}{ORCID})
 

--- a/tests/testthat/test-bowling_basics.R
+++ b/tests/testthat/test-bowling_basics.R
@@ -1,10 +1,24 @@
 
 # bowl_econ ----------------------------------------------------
 
-test_that("bowl_econ works", {
+test_that("bowl_econ works for overs", {
   expect_equal(bowl_econ(balls_bowled = 60, runs_conceded = 45), 4.5)
-  expect_equal(bowl_econ(overs_to_balls(overs = 7.1), runs_conceded = 26) %>%
+  expect_equal(bowl_econ(overs_to_balls(overs = 7.1), runs_conceded = 26, type = "overs") %>%
     round(digits = 2), 3.63)
+})
+
+test_that("bowl_econ works for sets or per hundred", {
+  expect_equal(bowl_econ(balls_bowled = 30, runs_conceded = 35, type = "sets") %>%
+    round(digits = 2), 5.83)
+  expect_equal(bowl_econ(balls_bowled = 22, runs_conceded = 19, type = "per_100") %>%
+    round(digits = 2), 86.36)
+})
+
+test_that("bowl_econ fails if type 'overs', 'sets', 'per_100' supplied",{
+
+  expect_error(bowl_econ(balls_bowled = 22, runs_conceded = 19, type = "per_200"),
+               regexp = "Type can either be overs or sets. Please Amend!")
+
 })
 
 


### PR DESCRIPTION
- Increment version number to `1.0.0.9001`
- Update `bowl_econ` function to include parameter `type` to allow to calculate Economy Rate per six ball overs, five ball sets or hundred balls bowled
- Update `README` to include examples of the above